### PR TITLE
fix: 혼동되는 이름 변경

### DIFF
--- a/src/codebuild/codebuild.controller.ts
+++ b/src/codebuild/codebuild.controller.ts
@@ -100,7 +100,7 @@ export class CodeBuildController {
    * {
    *   "buildId": "otto-user123-myapp:12345678-1234-1234-1234-123456789012",
    *   "buildStatus": "IN_PROGRESS",
-   *   "projectName": "otto-user123-myapp",
+   *   "codebuildProjectName": "otto-user123-myapp",
    *   "startTime": "2024-01-01T00:00:00Z",
    *   "currentPhase": "BUILD",
    *   "phases": [...],
@@ -156,7 +156,7 @@ export class CodeBuildController {
    * 4. 빌드 이력을 데이터베이스에 저장
    * 5. 빌드 ID 및 상태 반환
    *
-   * ## 프로젝트명 규칙
+   * ## CodeBuild 프로젝트명 규칙
    * AWS CodeBuild 프로젝트명은 `otto-{userId}-{projectId}` 형식으로 자동 생성됩니다.
    *
    * @method startFlowBuild
@@ -164,7 +164,7 @@ export class CodeBuildController {
    * @param {Request} req - 인증된 사용자 요청 객체 (JWT 토큰에서 사용자 정보 추출)
    * @param {string} projectId - 빌드를 실행할 프로젝트 ID
    * @param {FlowPipelineInput} flowPipelineInput - FlowBlock 기반 파이프라인 설정
-   * @returns {Promise<BuildResponse>} 빌드 시작 결과 (buildId, buildStatus, projectName, startTime)
+   * @returns {Promise<BuildResponse>} 빌드 시작 결과 (buildId, buildStatus, codebuildProjectName, startTime)
    *
    * @throws {HttpException} 404 - 프로젝트를 찾을 수 없거나 접근 권한이 없는 경우
    * @throws {HttpException} 400 - 잘못된 빌드 설정인 경우
@@ -226,7 +226,7 @@ export class CodeBuildController {
    * {
    *   "buildId": "otto-user123-proj_1234567890_abc123def:build-id-123",
    *   "buildStatus": "IN_PROGRESS",
-   *   "projectName": "otto-user123-proj_1234567890_abc123def",
+   *   "codebuildProjectName": "otto-user123-proj_1234567890_abc123def",
    *   "startTime": "2024-01-01T00:00:00Z"
    * }
    * ```
@@ -270,7 +270,7 @@ export class CodeBuildController {
       if (error.name === 'ResourceNotFoundException') {
         throw new HttpException(
           // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-          `CodeBuild project not found: ${error.message}`,
+          `CodeBuild project not found for build: ${error.message}`,
           HttpStatus.NOT_FOUND,
         );
       }

--- a/src/codebuild/types/codebuild.types.ts
+++ b/src/codebuild/types/codebuild.types.ts
@@ -7,7 +7,7 @@ import type {
  * 빌드 시작 응답 인터페이스
  *
  * AWS CodeBuild에서 빌드를 시작했을 때 반환되는 기본 정보를 정의합니다.
- * 빌드 ID, 상태, 프로젝트명, 시작 시간 등의 정보를 포함합니다.
+ * 빌드 ID, 상태, CodeBuild 프로젝트명, 시작 시간 등의 정보를 포함합니다.
  *
  * @since 1.0.0
  */
@@ -17,7 +17,7 @@ export interface BuildResponse {
   /** 현재 빌드 상태 (SUCCEEDED, FAILED, IN_PROGRESS 등) */
   buildStatus: string;
   /** AWS CodeBuild 프로젝트명 */
-  projectName: string;
+  codebuildProjectName: string;
   /** 빌드 시작 시간 (선택사항) */
   startTime?: Date;
 }
@@ -37,7 +37,7 @@ export interface BuildStatusResponse {
   /** 현재 빌드 상태 (SUCCEEDED, FAILED, IN_PROGRESS 등) */
   buildStatus: string;
   /** AWS CodeBuild 프로젝트명 */
-  projectName: string;
+  codebuildProjectName: string;
   /** 빌드 시작 시간 (선택사항) */
   startTime?: Date;
   /** 빌드 종료 시간 (완료된 경우에만) */


### PR DESCRIPTION
🎯 변경 사항 요약

  사용자 프로젝트와 AWS CodeBuild 프로젝트 간 명칭 혼동을
  방지하기 위해 API 응답 필드명을 변경했습니다.

  🔧 주요 변경 내용

  - projectName → codebuildProjectName으로 필드명 변경
    - BuildResponse 인터페이스
    - BuildStatusResponse 인터페이스
    - 관련 서비스 및 컨트롤러 로직

  📝 변경 이유

  Otto 서비스는 두 가지 프로젝트 개념을 사용합니다:
  1. 사용자 프로젝트: GitHub 레포지토리와 연결된 Otto 서비스의       
  프로젝트
  2. CodeBuild 프로젝트: AWS CodeBuild에서 실제 빌드를 수행하는      
  프로젝트

  기존에 projectName이라는 동일한 명칭을 사용하여 혼동의 여지가      
  있었습니다. 이를 명확히 구분하기 위해 AWS CodeBuild 관련 필드를    
   codebuildProjectName으로 변경했습니다.

  ✅ 영향 범위

  - Backend API 응답 형식 변경
    - /api/codebuild/status/:buildId
    - /api/codebuild/:projectId/start-flow
  - Breaking Change: API 응답 필드명이 변경되어 프론트엔드
  업데이트 필요

  🔍 테스트

  - 빌드 시작 API 정상 동작 확인
  - 빌드 상태 조회 API 정상 동작 확인
  - 프론트엔드 연동 테스트 필요

  📌 추가 작업 필요

  - 프론트엔드에서 projectName → codebuildProjectName 필드명 변경    
  - API 문서 업데이트