### PR TITLE
feat: Add GitHub webhook support and improve CodeBuild project handling

### DIFF
--- a/src/codebuild/codebuild.service.ts
+++ b/src/codebuild/codebuild.service.ts
@@ -971,7 +971,7 @@ export class CodeBuildService {
         // 프로젝트의 활성 파이프라인 조회
         const { data: pipeline } = await this.supabaseService
           .getClient()
-          .from('pipeline')
+          .from('pipelines')
           .select('id, blocks, artifacts, environment_variables, cache')
           .eq('project_id', projectId)
           .single();

--- a/src/github-integration/github-integration.module.ts
+++ b/src/github-integration/github-integration.module.ts
@@ -1,11 +1,13 @@
 import { Module } from '@nestjs/common';
 import { GithubIntegrationController } from './github-integration.controller';
 import { GithubIntegrationService } from './github-integration.service';
+import { GithubWebhookController } from './github-webhook.controller';
 import { SupabaseModule } from '../supabase/supabase.module';
+import { ConfigModule } from '@nestjs/config';
 
 @Module({
-  imports: [SupabaseModule],
-  controllers: [GithubIntegrationController],
+  imports: [SupabaseModule, ConfigModule],
+  controllers: [GithubIntegrationController, GithubWebhookController],
   providers: [GithubIntegrationService],
   exports: [GithubIntegrationService],
 })

--- a/src/github-integration/github-webhook.controller.ts
+++ b/src/github-integration/github-webhook.controller.ts
@@ -11,7 +11,10 @@ import {
 import { createHmac } from 'crypto';
 import { SupabaseService } from '../supabase/supabase.service';
 import { ConfigService } from '@nestjs/config';
-import type { GithubWebhookPayload, GithubRepository } from './types/webhook.types';
+import type {
+  GithubWebhookPayload,
+  GithubRepository,
+} from './types/webhook.types';
 
 @Controller('github')
 export class GithubWebhookController {
@@ -58,13 +61,13 @@ export class GithubWebhookController {
           await this.handleInstallation(payload);
           break;
         case 'installation_repositories':
-          await this.handleInstallationRepositories(payload);
+          this.handleInstallationRepositories(payload);
           break;
         case 'push':
-          await this.handlePush(payload);
+          this.handlePush(payload);
           break;
         case 'pull_request':
-          await this.handlePullRequest(payload);
+          this.handlePullRequest(payload);
           break;
         default:
           this.logger.log(
@@ -127,7 +130,7 @@ export class GithubWebhookController {
         return;
       }
 
-      const user = users[0];
+      const user = users[0] as { id: string };
 
       // Installation 정보 저장
       const { data: existingInstall } = await client
@@ -191,7 +194,7 @@ export class GithubWebhookController {
    * - added: 저장소 추가
    * - removed: 저장소 제거
    */
-  private async handleInstallationRepositories(payload: GithubWebhookPayload) {
+  private handleInstallationRepositories(payload: GithubWebhookPayload) {
     const { action, installation, repositories_added, repositories_removed } =
       payload;
 
@@ -226,8 +229,8 @@ export class GithubWebhookController {
   /**
    * Push 이벤트 처리
    */
-  private async handlePush(payload: GithubWebhookPayload) {
-    const { repository, ref, pusher, commits } = payload;
+  private handlePush(payload: GithubWebhookPayload) {
+    const { repository, ref, pusher } = payload;
 
     if (!repository || !pusher) {
       this.logger.warn('[GitHub Webhook] Missing repository or pusher data');
@@ -244,11 +247,13 @@ export class GithubWebhookController {
   /**
    * Pull Request 이벤트 처리
    */
-  private async handlePullRequest(payload: GithubWebhookPayload) {
+  private handlePullRequest(payload: GithubWebhookPayload) {
     const { action, pull_request, repository } = payload;
 
     if (!repository || !pull_request) {
-      this.logger.warn('[GitHub Webhook] Missing repository or pull_request data');
+      this.logger.warn(
+        '[GitHub Webhook] Missing repository or pull_request data',
+      );
       return;
     }
 

--- a/src/github-integration/github-webhook.controller.ts
+++ b/src/github-integration/github-webhook.controller.ts
@@ -1,0 +1,228 @@
+import {
+  Controller,
+  Post,
+  Body,
+  Headers,
+  HttpCode,
+  HttpStatus,
+  Logger,
+  BadRequestException,
+} from '@nestjs/common';
+import { createHmac } from 'crypto';
+import { SupabaseService } from '../supabase/supabase.service';
+import { ConfigService } from '@nestjs/config';
+
+@Controller('github')
+export class GithubWebhookController {
+  private readonly logger = new Logger(GithubWebhookController.name);
+
+  constructor(
+    private readonly supabase: SupabaseService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  /**
+   * GitHub Webhook 엔드포인트
+   * GitHub App의 모든 이벤트를 수신
+   */
+  @Post('webhook')
+  @HttpCode(HttpStatus.OK)
+  async handleWebhook(
+    @Body() payload: any,
+    @Headers('x-hub-signature-256') signature: string,
+    @Headers('x-github-event') githubEvent: string,
+  ) {
+    this.logger.log(`[GitHub Webhook] Received event: ${githubEvent}`);
+
+    // 서명 검증
+    const webhookSecret = this.configService.get<string>('OTTO_GITHUB_WEBHOOK_SECRET');
+    if (webhookSecret && signature) {
+      const isValid = this.verifyWebhookSignature(payload, signature, webhookSecret);
+      if (!isValid) {
+        this.logger.error('[GitHub Webhook] Invalid signature');
+        throw new BadRequestException('Invalid signature');
+      }
+    }
+
+    try {
+      // 이벤트 타입별 처리
+      switch (githubEvent) {
+        case 'installation':
+          await this.handleInstallation(payload);
+          break;
+        case 'installation_repositories':
+          await this.handleInstallationRepositories(payload);
+          break;
+        case 'push':
+          await this.handlePush(payload);
+          break;
+        case 'pull_request':
+          await this.handlePullRequest(payload);
+          break;
+        default:
+          this.logger.log(`[GitHub Webhook] Unhandled event type: ${githubEvent}`);
+      }
+
+      return { status: 'ok' };
+    } catch (error) {
+      this.logger.error('[GitHub Webhook] Error processing webhook:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Webhook 서명 검증
+   */
+  private verifyWebhookSignature(
+    payload: any,
+    signature: string,
+    secret: string,
+  ): boolean {
+    const hmac = createHmac('sha256', secret);
+    const digest = 'sha256=' + hmac.update(JSON.stringify(payload)).digest('hex');
+    return signature === digest;
+  }
+
+  /**
+   * Installation 이벤트 처리
+   * - created: 새로운 설치
+   * - deleted: 설치 제거
+   */
+  private async handleInstallation(payload: any) {
+    const { action, installation, sender } = payload;
+    
+    this.logger.log(`[GitHub Webhook] Installation ${action}: ${installation.id}`);
+
+    if (action === 'created') {
+      // GitHub 사용자 정보로 Otto 사용자 찾기
+      const client = this.supabase.getClient();
+      
+      const { data: users, error: userError } = await client
+        .from('users')
+        .select('*')
+        .or(`github_username.eq.${sender.login},username.eq.${sender.login}`)
+        .limit(1);
+
+      if (userError || !users || users.length === 0) {
+        this.logger.warn(
+          `[GitHub Webhook] User not found for GitHub login: ${sender.login}`,
+        );
+        return;
+      }
+
+      const user = users[0];
+
+      // Installation 정보 저장
+      const { data: existingInstall } = await client
+        .from('github_installations')
+        .select('*')
+        .eq('installation_id', String(installation.id))
+        .single();
+
+      const installationData = {
+        installation_id: String(installation.id),
+        user_id: user.id,
+        account_login: installation.account.login,
+        account_type: installation.account.type,
+        repository_selection: installation.repository_selection,
+        permissions: installation.permissions || {},
+        events: installation.events || [],
+        is_active: true,
+        created_at: installation.created_at,
+        updated_at: installation.updated_at,
+      };
+
+      if (existingInstall) {
+        // Update existing
+        await client
+          .from('github_installations')
+          .update({
+            is_active: true,
+            repository_selection: installation.repository_selection,
+            permissions: installation.permissions || {},
+            events: installation.events || [],
+            updated_at: installation.updated_at,
+          })
+          .eq('installation_id', String(installation.id));
+      } else {
+        // Create new
+        await client
+          .from('github_installations')
+          .insert(installationData);
+      }
+
+      this.logger.log(
+        `[GitHub Webhook] Installation saved: ${installation.id} for user: ${user.id}`,
+      );
+    } else if (action === 'deleted') {
+      // Installation 비활성화
+      const client = this.supabase.getClient();
+      await client
+        .from('github_installations')
+        .update({
+          is_active: false,
+          updated_at: new Date().toISOString(),
+        })
+        .eq('installation_id', String(installation.id));
+
+      this.logger.log(`[GitHub Webhook] Installation deactivated: ${installation.id}`);
+    }
+  }
+
+  /**
+   * Installation Repositories 이벤트 처리
+   * - added: 저장소 추가
+   * - removed: 저장소 제거
+   */
+  private async handleInstallationRepositories(payload: any) {
+    const { action, installation, repositories_added, repositories_removed } = payload;
+    
+    this.logger.log(
+      `[GitHub Webhook] Installation repositories ${action} for installation: ${installation.id}`,
+    );
+
+    if (repositories_added && repositories_added.length > 0) {
+      this.logger.log(
+        `[GitHub Webhook] Repositories added: ${repositories_added
+          .map((r: any) => r.full_name)
+          .join(', ')}`,
+      );
+      // 필요시 저장소 정보 저장
+    }
+
+    if (repositories_removed && repositories_removed.length > 0) {
+      this.logger.log(
+        `[GitHub Webhook] Repositories removed: ${repositories_removed
+          .map((r: any) => r.full_name)
+          .join(', ')}`,
+      );
+      // 필요시 저장소 정보 제거
+    }
+  }
+
+  /**
+   * Push 이벤트 처리
+   */
+  private async handlePush(payload: any) {
+    const { repository, ref, pusher, commits } = payload;
+    
+    this.logger.log(
+      `[GitHub Webhook] Push to ${repository.full_name} on ${ref} by ${pusher.name}`,
+    );
+
+    // 필요시 빌드 트리거 등 처리
+  }
+
+  /**
+   * Pull Request 이벤트 처리
+   */
+  private async handlePullRequest(payload: any) {
+    const { action, pull_request, repository } = payload;
+    
+    this.logger.log(
+      `[GitHub Webhook] Pull request ${action} on ${repository.full_name}: #${pull_request.number}`,
+    );
+
+    // 필요시 PR 빌드 트리거 등 처리
+  }
+}

--- a/src/github-integration/types/webhook.types.ts
+++ b/src/github-integration/types/webhook.types.ts
@@ -1,0 +1,69 @@
+// GitHub Webhook Event Types
+export interface GithubWebhookPayload {
+  action?: string;
+  installation?: GithubInstallation;
+  sender?: GithubUser;
+  repository?: GithubRepository;
+  repositories_added?: GithubRepository[];
+  repositories_removed?: GithubRepository[];
+  ref?: string;
+  pusher?: {
+    name: string;
+    email?: string;
+  };
+  commits?: Array<{
+    id: string;
+    message: string;
+    author: {
+      name: string;
+      email: string;
+    };
+  }>;
+  pull_request?: GithubPullRequest;
+}
+
+export interface GithubInstallation {
+  id: number;
+  account: {
+    login: string;
+    type: string;
+  };
+  repository_selection?: string;
+  permissions?: Record<string, string>;
+  events?: string[];
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface GithubUser {
+  login: string;
+  id: number;
+  avatar_url?: string;
+  type?: string;
+}
+
+export interface GithubRepository {
+  id: number;
+  name: string;
+  full_name: string;
+  owner?: GithubUser;
+  private?: boolean;
+  html_url?: string;
+  description?: string;
+}
+
+export interface GithubPullRequest {
+  id: number;
+  number: number;
+  title: string;
+  body?: string;
+  state: string;
+  head: {
+    ref: string;
+    sha: string;
+  };
+  base: {
+    ref: string;
+    sha: string;
+  };
+}

--- a/src/pipeline/dto/requests/update-pipeline.dto.ts
+++ b/src/pipeline/dto/requests/update-pipeline.dto.ts
@@ -1,4 +1,5 @@
 export interface UpdatePipelineDto {
+  name?: string;
   flowData?: {
     nodes: any[];
     edges: any[];

--- a/src/pipeline/pipeline.service.ts
+++ b/src/pipeline/pipeline.service.ts
@@ -75,20 +75,20 @@ export class PipelineService {
     id: string,
     updatePipelineDto: UpdatePipelineDto,
   ): Promise<PipelineResponse> {
-    const updateData: any = {};
-    
+    const updateData: Record<string, unknown> = {};
+
     if (updatePipelineDto.name !== undefined) {
       updateData.name = updatePipelineDto.name;
     }
-    
+
     if (updatePipelineDto.flowData !== undefined) {
       updateData.data = updatePipelineDto.flowData;
     }
-    
+
     if (updatePipelineDto.env !== undefined) {
       updateData.env = updatePipelineDto.env;
     }
-    
+
     const { data, error } = await this.supabaseService
       .getClient()
       .from('pipeline')
@@ -123,11 +123,19 @@ export class PipelineService {
     }
   }
 
-  private mapToResponse(pipeline: any): PipelineResponse {
+  private mapToResponse(pipeline: {
+    pipeline_id: string;
+    project_id: string;
+    name?: string;
+    data: { nodes: unknown[]; edges: unknown[] };
+    created_at: string;
+  }): PipelineResponse {
     return {
       id: pipeline.pipeline_id,
       projectId: pipeline.project_id,
-      name: pipeline.name || `Pipeline ${new Date(pipeline.created_at).toLocaleString()}`, // DB의 name 필드 사용
+      name:
+        pipeline.name ||
+        `Pipeline ${new Date(pipeline.created_at).toLocaleString()}`, // DB의 name 필드 사용
       description: 'Pipeline created from dashboard', // 기존 스키마에 description 필드가 없어서 기본값
       flowData: pipeline.data,
       isActive: true, // 기존 스키마에 isActive 필드가 없어서 기본값

--- a/src/pipeline/pipeline.service.ts
+++ b/src/pipeline/pipeline.service.ts
@@ -7,7 +7,6 @@ import {
   PipelineResponse,
   PipelinesListResponse,
 } from './dto';
-import { PipelineEntity } from '../types/pipeline.types';
 
 @Injectable()
 export class PipelineService {
@@ -19,7 +18,7 @@ export class PipelineService {
     // 기존 데이터 업데이트 (upsert)
     const { data, error } = await this.supabaseService
       .getClient()
-      .from('pipeline')
+      .from('pipelines')
       .upsert({
         project_id: createPipelineDto.projectId,
         name: createPipelineDto.name,
@@ -41,7 +40,7 @@ export class PipelineService {
   ): Promise<PipelinesListResponse> {
     const { data, error } = await this.supabaseService
       .getClient()
-      .from('pipeline')
+      .from('pipelines')
       .select('*')
       .eq('project_id', getPipelinesDto.projectId)
       .order('created_at', { ascending: false });
@@ -59,7 +58,7 @@ export class PipelineService {
   async getPipelineById(id: string): Promise<PipelineResponse> {
     const { data, error } = await this.supabaseService
       .getClient()
-      .from('pipeline')
+      .from('pipelines')
       .select('*')
       .eq('pipeline_id', id)
       .single();
@@ -91,7 +90,7 @@ export class PipelineService {
 
     const { data, error } = await this.supabaseService
       .getClient()
-      .from('pipeline')
+      .from('pipelines')
       .update(updateData)
       .eq('pipeline_id', id)
       .select();
@@ -112,7 +111,7 @@ export class PipelineService {
   async deletePipeline(id: string): Promise<void> {
     const { error } = await this.supabaseService
       .getClient()
-      .from('pipeline')
+      .from('pipelines')
       .delete()
       .eq('pipeline_id', id);
 

--- a/src/pipeline/types/pipeline-db.types.ts
+++ b/src/pipeline/types/pipeline-db.types.ts
@@ -1,0 +1,34 @@
+/**
+ * Database types for pipeline table
+ */
+export interface PipelineDB {
+  pipeline_id: string;
+  project_id: string;
+  name?: string | null;
+  data: {
+    nodes: Array<{
+      id: string;
+      type?: string;
+      position?: { x: number; y: number };
+      data?: Record<string, unknown>;
+    }>;
+    edges: Array<{
+      id: string;
+      source: string;
+      target: string;
+      type?: string;
+      data?: Record<string, unknown>;
+    }>;
+  };
+  env?: Record<string, unknown> | null;
+  created_at: string;
+  updated_at?: string;
+}
+
+export type PipelineInsert = Omit<
+  PipelineDB,
+  'pipeline_id' | 'created_at' | 'updated_at'
+>;
+export type PipelineUpdate = Partial<
+  Omit<PipelineDB, 'pipeline_id' | 'project_id' | 'created_at'>
+>;

--- a/src/projects/dto/project.dto.ts
+++ b/src/projects/dto/project.dto.ts
@@ -40,6 +40,7 @@ export interface CreateProjectWithGithubRequest {
 
 export interface CreateProjectWithGithubResponse {
   project: Project;
+  pipelineId?: string | null;
 }
 
 export interface UpdateProjectRequest {

--- a/src/projects/services/project.service.ts
+++ b/src/projects/services/project.service.ts
@@ -908,10 +908,10 @@ artifacts:
       },
     };
 
-    // pipeline 테이블에 insert (프로젝트당 하나의 파이프라인)
+    // pipelines 테이블에 insert (프로젝트당 하나의 파이프라인)
     const { data, error } = await this.supabaseService
       .getClient()
-      .from('pipeline')
+      .from('pipelines')
       .insert({
         project_id: projectId,
         data: defaultPipeline,

--- a/src/projects/services/project.service.ts
+++ b/src/projects/services/project.service.ts
@@ -38,17 +38,6 @@ export class ProjectService {
         `[ProjectService] getUserProjects called for userId: ${userId}`,
       );
 
-      // 먼저 모든 프로젝트 조회 (디버깅용)
-      const { data: allProjects } = await this.supabaseService
-        .getClient()
-        .from('projects')
-        .select('project_id, name, user_id')
-        .limit(10);
-      
-      this.logger.log(
-        `[ProjectService] All projects in DB: ${JSON.stringify(allProjects)}`,
-      );
-
       // 사용자의 프로젝트 조회
       const { data: projects, error } = await this.supabaseService
         .getClient()
@@ -199,31 +188,21 @@ export class ProjectService {
       }
 
       // 1. 프로젝트 생성
-      this.logger.log(
-        `[ProjectService] Creating project with userId: ${userId}`,
-      );
-      
-      const projectData = {
-        name,
-        description,
-        github_owner: githubOwner,
-        github_repo_id: githubRepoId,
-        github_repo_name: githubRepoName,
-        github_repo_url: githubRepoUrl,
-        installation_id: installationId,
-        user_id: userId,
-        selected_branch: selectedBranch || 'main',
-        codebuild_status: 'PENDING',
-      };
-      
-      this.logger.log(
-        `[ProjectService] Project data to insert: ${JSON.stringify(projectData)}`,
-      );
-      
       const { data: project, error: projectError } = await this.supabaseService
         .getClient()
         .from('projects')
-        .insert(projectData)
+        .insert({
+          name,
+          description,
+          github_owner: githubOwner,
+          github_repo_id: githubRepoId,
+          github_repo_name: githubRepoName,
+          github_repo_url: githubRepoUrl,
+          installation_id: installationId,
+          user_id: userId,
+          selected_branch: selectedBranch || 'main',
+          codebuild_status: 'PENDING',
+        })
         .select()
         .single();
 
@@ -942,26 +921,20 @@ artifacts:
       .single();
 
     if (error) {
-      this.logger.error(
-        `Failed to create default pipeline: ${error.message}`,
-        {
-          projectId,
-          errorCode: error.code,
-          errorDetails: error.details,
-          errorHint: error.hint,
-        },
-      );
+      this.logger.error(`Failed to create default pipeline: ${error.message}`, {
+        projectId,
+        errorCode: error.code,
+        errorDetails: error.details,
+        errorHint: error.hint,
+      });
       throw new Error(`Failed to create default pipeline: ${error.message}`);
     }
 
     if (data) {
-      this.logger.log(
-        `Default pipeline created successfully:`,
-        {
-          pipelineId: data.pipeline_id,
-          projectId: data.project_id,
-        },
-      );
+      this.logger.log(`Default pipeline created successfully:`, {
+        pipelineId: data.pipeline_id,
+        projectId: data.project_id,
+      });
     }
 
     this.logger.log(


### PR DESCRIPTION
## 개요
GitHub 웹훅 처리 기능을 추가하고 CodeBuild 프로젝트 중복 생성 문제를 해결했습니다.
또한 Pipeline 서비스의 기능을 개선하고 타입 안정성을 강화했습니다.

## 변경 사항
#### 1. GitHub 웹훅 처리 기능 추가
  - 새로운 GithubWebhookController 추가
  - /github/webhook 엔드포인트로 GitHub App 이벤트 수신
  - HMAC SHA-256 서명 검증으로 보안 강화
  - Installation, Push, Pull Request 등 주요 이벤트 처리
  - 타입 안전성을 위한 GithubWebhookPayload 타입 정의

#### 2. CodeBuild 프로젝트 중복 생성 문제 개선
  - ResourceAlreadyExistsException 예외 처리
  - 기존 프로젝트 조회 후 소스 설정 업데이트
  - BatchGetProjectsCommand, UpdateProjectCommand 추가
  - 프로젝트 삭제 기능 (deleteCodeBuildProject) 구현

#### 3. Pipeline 서비스 개선
  - Pipeline name 필드 추가 및 업데이트 지원
  - 조건부 업데이트 로직으로 필요한 필드만 선택적 업데이트
  - 에러 처리 및 응답 검증 강화
  - 기본 파이프라인에 branch_push_trigger 블록 추가

#### 4. 코드 품질 개선
  - 모든 any 타입을 구체적 타입으로 대체
  - TypeScript strict 모드 준수
  - import type 사용으로 decorator 호환성 개선
  - 프로덕션 환경에 불필요한 로그 제거
  - 코드 가독성 향상

## 관련 이슈
- CodeBuild 프로젝트 중복 생성 문제
- GitHub App 이벤트 처리 미구현
- Pipeline 관리 기능 부족