### PR TITLE
feat: Add endpoint to fetch build histories by project ID

### DIFF
--- a/src/builds/builds.service.ts
+++ b/src/builds/builds.service.ts
@@ -493,7 +493,8 @@ export class BuildsService {
         (b) =>
           (b.build_execution_status === 'succeeded' ||
             b.build_execution_status === 'failed') &&
-          b.duration_seconds,
+          b.duration_seconds !== null &&
+          b.duration_seconds !== undefined,
       );
       const averageDurationSeconds =
         completedBuildsWithDuration.length > 0

--- a/src/builds/builds.service.ts
+++ b/src/builds/builds.service.ts
@@ -475,7 +475,12 @@ export class BuildsService {
         throw error;
       }
 
-      const builds = data || [];
+      interface BuildStatRecord {
+        build_execution_status?: string;
+        duration_seconds?: number;
+      }
+
+      const builds = (data || []) as BuildStatRecord[];
       const totalBuilds = builds.length;
       const succeededBuilds = builds.filter(
         (b) => b.build_execution_status === 'succeeded',

--- a/src/codebuild/codebuild.service.ts
+++ b/src/codebuild/codebuild.service.ts
@@ -493,7 +493,7 @@ export class CodeBuildService {
         if (envBlock.environmentVariables) {
           Object.entries(envBlock.environmentVariables).forEach(
             ([key, value]) => {
-              commands.push(`export ${key}="${value}"`);
+              commands.push(`export ${key}="${String(value)}"`);
             },
           );
         }

--- a/src/codebuild/types/pipeline-input.types.ts
+++ b/src/codebuild/types/pipeline-input.types.ts
@@ -1,5 +1,5 @@
 /**
- * @fileoverview camelCase 기반 Pipeline 입력 타입 정의 
+ * @fileoverview camelCase 기반 Pipeline 입력 타입 정의
  * @description otto-ui에서 전송하는 camelCase JSON을 위한 타입 시스템
  * @module pipeline-input.types
  */
@@ -10,32 +10,32 @@
 export enum CICDBlockType {
   // Pipeline Start
   PIPELINE_START = 'pipeline_start',
-  
+
   // Prebuild
   OS_PACKAGE = 'os_package',
-  NODE_VERSION = 'node_version', 
+  NODE_VERSION = 'node_version',
   ENVIRONMENT_SETUP = 'environment_setup',
-  
+
   // Build
   INSTALL_MODULE_NODE = 'install_module_node',
   BUILD_WEBPACK = 'build_webpack',
   BUILD_VITE = 'build_vite',
   BUILD_CUSTOM = 'build_custom',
-  
+
   // Test
   TEST_JEST = 'test_jest',
-  TEST_MOCHA = 'test_mocha', 
+  TEST_MOCHA = 'test_mocha',
   TEST_VITEST = 'test_vitest',
   TEST_CUSTOM = 'test_custom',
-  
+
   // Notification
   NOTIFICATION_SLACK = 'notification_slack',
   NOTIFICATION_EMAIL = 'notification_email',
-  
+
   // Utility
   CONDITION_BRANCH = 'condition_branch',
   PARALLEL_EXECUTION = 'parallel_execution',
-  CUSTOM_COMMAND = 'custom_command'
+  CUSTOM_COMMAND = 'custom_command',
 }
 
 /**
@@ -43,11 +43,11 @@ export enum CICDBlockType {
  */
 export enum CICDBlockGroup {
   START = 'start',
-  PREBUILD = 'prebuild', 
+  PREBUILD = 'prebuild',
   BUILD = 'build',
   TEST = 'test',
   NOTIFICATION = 'notification',
-  UTILITY = 'utility'
+  UTILITY = 'utility',
 }
 
 /**

--- a/src/logs/logs.controller.ts
+++ b/src/logs/logs.controller.ts
@@ -9,6 +9,8 @@ import {
   MessageEvent,
   UsePipes,
   ValidationPipe,
+  DefaultValuePipe,
+  ParseIntPipe,
 } from '@nestjs/common';
 import { Observable, Subject } from 'rxjs';
 import { map, filter } from 'rxjs/operators';
@@ -337,6 +339,34 @@ export class LogsController {
       userId: query.userId,
       timeRange: query.timeRange,
       groupBy: query.groupBy,
+    });
+  }
+
+  /**
+   * 프로젝트 ID로 빌드 히스토리와 메타데이터 조회
+   *
+   * 프로젝트의 모든 빌드 히스토리와 각 빌드의 메타데이터를 조회합니다.
+   *
+   * @param projectId - 프로젝트 ID
+   * @param limit - 조회할 최대 빌드 개수 (기본값: 20)
+   * @param offset - 페이지네이션 오프셋 (기본값: 0)
+   * @returns 빌드 히스토리와 메타데이터 목록
+   *
+   * @example
+   * GET /logs/projects/ea32d77b-faae-499b-ab2d-f31e9d3bb1eb/builds
+   */
+  @Get('projects/:projectId/builds')
+  async getProjectBuildHistories(
+    @Param('projectId') projectId: string,
+    @Query('limit', new DefaultValuePipe(20), ParseIntPipe) limit: number,
+    @Query('offset', new DefaultValuePipe(0), ParseIntPipe) offset: number,
+  ): Promise<{
+    builds: Array<any>;
+    total: number;
+  }> {
+    return this.logsService.getProjectBuildHistories(projectId, {
+      limit: Math.min(limit, 100),
+      offset,
     });
   }
 

--- a/src/logs/logs.service.ts
+++ b/src/logs/logs.service.ts
@@ -94,7 +94,6 @@ function normalizeLogEvent(event: LogEvent): NormalizedLogEvent {
   }
 
   // Level 추론
-  const lower = msg.toLowerCase();
   let level: NormalizedLogEvent['level'] = 'INFO';
   if (/(error|failed)/i.test(msg)) level = 'ERROR';
   else if (/(warn|warning)/i.test(msg)) level = 'WARN';

--- a/src/pipeline/pipeline.service.ts
+++ b/src/pipeline/pipeline.service.ts
@@ -46,9 +46,7 @@ export class PipelineService {
     return this.mapToResponse(data);
   }
 
-  async getPipelinesByProject(
-    getPipelinesDto: GetPipelinesDto,
-  ): Promise<any> {
+  async getPipelinesByProject(getPipelinesDto: GetPipelinesDto): Promise<any> {
     const { data, error } = await this.supabaseService
       .getClient()
       .from('pipelines')


### PR DESCRIPTION
## 주요 변경사항
- GET /api/v1/logs/projects/:projectId/builds 엔드포인트 구현
- 프로젝트별 빌드 히스토리와 메타데이터 조회 기능 추가
- 빌드 상태 매핑 로직 구현 (DB 소문자 → API 대문자 변환)
    - succeeded → SUCCESS
    - failed → FAILED
    - in_progress → RUNNING
    - stopped → STOPPED
    - timed_out → TIMED_OUT
- 페이지네이션 지원 (limit, offset 파라미터)
- 각 빌드의 상세 정보 포함:
    - 빌드 상태, 트리거 정보, 리포지토리 정보
    - 실행 단계(phases), 메트릭(로그 라인 수, 에러/경고 카운트)
    - 아카이빙 상태, 실행 시간 정보

## 해결된 이슈
  - Supabase RLS 정책으로 인한 데이터 접근 문제 확인
  - 프론트엔드 로그 페이지에서 빌드 히스토리 조회 가능
