### PR TITLE
Feat: Code Deploy 연동 

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,6 +5,7 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { AuthModule } from './auth/auth.module';
 import { CodeBuildModule } from './codebuild/codebuild.module';
+import { CodeDeployModule } from './codedeploy/codedeploy.module';
 import { BuildsModule } from './builds/builds.module';
 import { CloudWatchLogsModule } from './cloudwatch-logs/cloudwatch-logs.module';
 import { GithubIntegrationModule } from './github-integration/github-integration.module';
@@ -39,6 +40,7 @@ import { PipelineModule } from './pipeline/pipeline.module';
     AuthModule,
     BuildsModule,
     CodeBuildModule,
+    CodeDeployModule,
     CloudWatchLogsModule,
     GithubIntegrationModule,
     ProjectsModule,

--- a/src/codedeploy/codedeploy.controller.ts
+++ b/src/codedeploy/codedeploy.controller.ts
@@ -1,0 +1,109 @@
+import {
+  Controller,
+  Post,
+  Get,
+  Body,
+  Param,
+  UseGuards,
+  Request,
+  Sse,
+  Logger,
+} from '@nestjs/common';
+import { Observable, interval } from 'rxjs';
+import { map, takeWhile } from 'rxjs/operators';
+import { CodeDeployService } from './codedeploy.service';
+import { SupabaseAuthGuard } from '../supabase/guards/supabase-auth.guard';
+import { DeploymentRequest, DeploymentConfig } from './types/codedeploy.types';
+
+@Controller('codedeploy')
+@UseGuards(SupabaseAuthGuard)
+export class CodeDeployController {
+  private readonly logger = new Logger(CodeDeployController.name);
+
+  constructor(private readonly codeDeployService: CodeDeployService) {}
+
+  /**
+   * 파이프라인에서 배포 실행
+   */
+  @Post('deploy-from-pipeline')
+  async deployFromPipeline(
+    @Request() req,
+    @Body() dto: {
+      buildId: string;
+      projectId: string;
+      nodeConfig: DeploymentConfig;
+    },
+  ) {
+    const userId = req.user.sub;
+
+    this.logger.log('Received deployment request from pipeline', {
+      userId,
+      buildId: dto.buildId,
+      projectId: dto.projectId,
+      environment: dto.nodeConfig.environment,
+    });
+
+    const request: DeploymentRequest = {
+      buildId: dto.buildId,
+      projectId: dto.projectId,
+      userId,
+      nodeConfig: dto.nodeConfig,
+    };
+
+    return this.codeDeployService.deployFromPipelineNode(request);
+  }
+
+  /**
+   * 배포 상태 조회
+   */
+  @Get('status/:deploymentId')
+  async getDeploymentStatus(@Param('deploymentId') deploymentId: string) {
+    this.logger.log('Getting deployment status', { deploymentId });
+    return this.codeDeployService.getDeploymentStatus(deploymentId);
+  }
+
+  /**
+   * 배포 인스턴스 목록 조회
+   */
+  @Get('instances/:deploymentId')
+  async listDeploymentInstances(@Param('deploymentId') deploymentId: string) {
+    this.logger.log('Listing deployment instances', { deploymentId });
+    return this.codeDeployService.listDeploymentInstances(deploymentId);
+  }
+
+  /**
+   * 배포 상태 실시간 스트리밍 (SSE)
+   */
+  @Sse('stream/:deploymentId')
+  streamDeploymentStatus(
+    @Param('deploymentId') deploymentId: string,
+  ): Observable<MessageEvent> {
+    this.logger.log('Starting deployment status stream', { deploymentId });
+
+    return interval(3000).pipe(
+      map(async () => {
+        try {
+          const status = await this.codeDeployService.getDeploymentStatus(deploymentId);
+
+          return {
+            data: JSON.stringify(status),
+            type: 'deployment-status',
+          } as MessageEvent;
+        } catch (error) {
+          this.logger.error('Error getting deployment status', error);
+          return {
+            data: JSON.stringify({ error: 'Failed to get status' }),
+            type: 'error',
+          } as MessageEvent;
+        }
+      }),
+      takeWhile(async (eventPromise) => {
+        const event = await eventPromise;
+        const data = JSON.parse(event.data);
+
+        // 완료 상태면 스트림 종료
+        return !['Succeeded', 'Failed', 'Stopped'].includes(data.status);
+      }, true),
+    );
+  }
+}

--- a/src/codedeploy/codedeploy.module.ts
+++ b/src/codedeploy/codedeploy.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { CodeDeployService } from './codedeploy.service';
+import { CodeDeployController } from './codedeploy.controller';
+import { SupabaseModule } from '../supabase/supabase.module';
+
+@Module({
+  imports: [ConfigModule, SupabaseModule],
+  providers: [CodeDeployService],
+  controllers: [CodeDeployController],
+  exports: [CodeDeployService],
+})
+export class CodeDeployModule {}

--- a/src/codedeploy/codedeploy.service.ts
+++ b/src/codedeploy/codedeploy.service.ts
@@ -1,0 +1,405 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  CodeDeployClient,
+  CreateApplicationCommand,
+  CreateDeploymentCommand,
+  CreateDeploymentGroupCommand,
+  GetApplicationCommand,
+  GetDeploymentCommand,
+  GetDeploymentGroupCommand,
+  UpdateDeploymentGroupCommand,
+  ListDeploymentInstancesCommand,
+  ApplicationDoesNotExistException,
+  DeploymentGroupDoesNotExistException,
+} from '@aws-sdk/client-codedeploy';
+import { SupabaseService } from '../supabase/supabase.service';
+import {
+  DeploymentConfig,
+  DeploymentResult,
+  DeploymentStatus,
+  S3ArtifactLocation,
+  DeploymentRequest,
+} from './types/codedeploy.types';
+
+@Injectable()
+export class CodeDeployService {
+  private readonly logger = new Logger(CodeDeployService.name);
+  private readonly client: CodeDeployClient;
+  private readonly serviceRole: string;
+  private readonly artifactsBucket: string;
+
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly supabaseService: SupabaseService,
+  ) {
+    const region = this.configService.get<string>('AWS_REGION') || 'ap-northeast-2';
+    const accessKeyId = this.configService.get<string>('AWS_ACCESS_KEY_ID');
+    const secretAccessKey = this.configService.get<string>('AWS_SECRET_ACCESS_KEY');
+
+    this.client = new CodeDeployClient({
+      region,
+      credentials: {
+        accessKeyId,
+        secretAccessKey,
+      },
+    });
+
+    this.serviceRole = this.configService.get<string>('AWS_CODEDEPLOY_SERVICE_ROLE');
+    this.artifactsBucket = this.configService.get<string>('CODEBUILD_ARTIFACTS_BUCKET');
+
+    this.logger.log('CodeDeploy service initialized', {
+      region,
+      serviceRole: this.serviceRole ? 'configured' : 'missing',
+      artifactsBucket: this.artifactsBucket,
+    });
+  }
+
+  /**
+   * 파이프라인 노드 설정으로부터 배포 실행
+   */
+  async deployFromPipelineNode(request: DeploymentRequest): Promise<DeploymentResult> {
+    const { buildId, projectId, userId, nodeConfig } = request;
+
+    this.logger.log('Starting deployment from pipeline node', {
+      buildId,
+      projectId,
+      userId,
+      environment: nodeConfig.environment,
+    });
+
+    try {
+      // 1. 빌드 정보 조회
+      const build = await this.getBuildInfo(buildId);
+      if (!build) {
+        throw new Error(`Build not found: ${buildId}`);
+      }
+
+      // 2. 애플리케이션 확인/생성
+      const appName = await this.ensureApplication(userId, projectId, nodeConfig);
+
+      // 3. 배포 그룹 확인/생성/업데이트
+      const deploymentGroupName = await this.ensureDeploymentGroup(
+        appName,
+        nodeConfig,
+        userId,
+      );
+
+      // 4. S3 아티팩트 위치 결정
+      const s3Location = this.getArtifactLocation(buildId, userId, projectId);
+
+      // 5. 배포 생성
+      const deploymentId = await this.createDeployment(
+        appName,
+        deploymentGroupName,
+        s3Location,
+        nodeConfig,
+      );
+
+      // 6. DB에 배포 정보 저장
+      await this.saveDeploymentInfo(deploymentId, buildId, projectId, userId, nodeConfig);
+
+      return {
+        deploymentId,
+        applicationName: appName,
+        deploymentGroupName,
+        status: 'InProgress',
+        createTime: new Date(),
+      };
+    } catch (error) {
+      this.logger.error('Failed to deploy from pipeline node', error);
+      throw error;
+    }
+  }
+
+  /**
+   * 빌드 정보 조회
+   */
+  private async getBuildInfo(buildId: string) {
+    const { data: build, error } = await this.supabaseService.client
+      .from('builds')
+      .select('*')
+      .eq('build_id', buildId)
+      .single();
+
+    if (error) {
+      this.logger.error('Failed to get build info', error);
+      return null;
+    }
+
+    return build;
+  }
+
+  /**
+   * 애플리케이션 확인 및 생성
+   */
+  private async ensureApplication(
+    userId: string,
+    projectId: string,
+    nodeConfig: DeploymentConfig,
+  ): Promise<string> {
+    const sanitizedProjectId = projectId.replace(/[^a-zA-Z0-9-]/g, '-');
+    const appName = `otto-${nodeConfig.environment}-${sanitizedProjectId}`.substring(0, 100);
+
+    try {
+      // 애플리케이션 존재 확인
+      await this.client.send(new GetApplicationCommand({
+        applicationName: appName,
+      }));
+
+      this.logger.log(`Application ${appName} already exists`);
+    } catch (error) {
+      if (error instanceof ApplicationDoesNotExistException || error.name === 'ApplicationDoesNotExistException') {
+        // 애플리케이션 생성
+        this.logger.log(`Creating new application: ${appName}`);
+
+        await this.client.send(new CreateApplicationCommand({
+          applicationName: appName,
+          computePlatform: 'Server', // EC2/On-premises
+          tags: [
+            { Key: 'UserId', Value: userId },
+            { Key: 'ProjectId', Value: projectId },
+            { Key: 'Environment', Value: nodeConfig.environment },
+            { Key: 'ManagedBy', Value: 'Otto' },
+          ],
+        }));
+      } else {
+        throw error;
+      }
+    }
+
+    return appName;
+  }
+
+  /**
+   * 배포 그룹 확인/생성/업데이트
+   */
+  private async ensureDeploymentGroup(
+    appName: string,
+    nodeConfig: DeploymentConfig,
+    userId: string,
+  ): Promise<string> {
+    const deploymentGroupName = `${nodeConfig.environment}-group`;
+
+    // EC2 태그 필터 구성
+    const ec2TagFilters = nodeConfig.instanceTags?.map(tag => ({
+      Type: 'KEY_AND_VALUE',
+      Key: tag.key,
+      Value: tag.value,
+    })) || [
+      {
+        Type: 'KEY_AND_VALUE',
+        Key: 'Environment',
+        Value: nodeConfig.environment,
+      },
+    ];
+
+    // 배포 설정 맵핑
+    const deploymentConfigName = this.mapDeploymentStrategy(nodeConfig.deploymentStrategy?.type);
+
+    // 자동 롤백 설정
+    const autoRollbackConfiguration = {
+      enabled: nodeConfig.rollbackConfig?.enabled || true,
+      events: [],
+    };
+
+    if (nodeConfig.rollbackConfig?.onDeploymentFailure) {
+      autoRollbackConfiguration.events.push('DEPLOYMENT_FAILURE');
+    }
+    if (nodeConfig.rollbackConfig?.onAlarmThreshold) {
+      autoRollbackConfiguration.events.push('DEPLOYMENT_STOP_ON_ALARM');
+    }
+
+    const deploymentGroupParams = {
+      applicationName: appName,
+      deploymentGroupName,
+      serviceRoleArn: this.serviceRole,
+      ec2TagFilters,
+      deploymentConfigName,
+      autoRollbackConfiguration,
+    };
+
+    try {
+      // 배포 그룹 존재 확인
+      await this.client.send(new GetDeploymentGroupCommand({
+        applicationName: appName,
+        deploymentGroupName,
+      }));
+
+      // 존재하면 업데이트
+      this.logger.log(`Updating deployment group: ${deploymentGroupName}`);
+
+      await this.client.send(new UpdateDeploymentGroupCommand({
+        ...deploymentGroupParams,
+        currentDeploymentGroupName: deploymentGroupName,
+      }));
+    } catch (error) {
+      if (error instanceof DeploymentGroupDoesNotExistException || error.name === 'DeploymentGroupDoesNotExistException') {
+        // 존재하지 않으면 생성
+        this.logger.log(`Creating deployment group: ${deploymentGroupName}`);
+
+        await this.client.send(new CreateDeploymentGroupCommand(deploymentGroupParams));
+      } else {
+        throw error;
+      }
+    }
+
+    return deploymentGroupName;
+  }
+
+  /**
+   * S3 아티팩트 위치 결정
+   */
+  private getArtifactLocation(
+    buildId: string,
+    userId: string,
+    projectId: string,
+  ): S3ArtifactLocation {
+    // CodeBuild가 저장한 S3 경로 구성
+    const sanitizedProjectId = projectId.replace(/[^a-zA-Z0-9-]/g, '-');
+
+    return {
+      bucket: this.artifactsBucket,
+      key: `otto-${sanitizedProjectId}-${userId}-artifacts/${buildId}`,
+      bundleType: 'zip',
+    };
+  }
+
+  /**
+   * 배포 생성
+   */
+  private async createDeployment(
+    appName: string,
+    deploymentGroupName: string,
+    s3Location: S3ArtifactLocation,
+    nodeConfig: DeploymentConfig,
+  ): Promise<string> {
+    const result = await this.client.send(new CreateDeploymentCommand({
+      applicationName: appName,
+      deploymentGroupName,
+      revision: {
+        revisionType: 'S3',
+        s3Location,
+      },
+      description: `Deployment: ${nodeConfig.deploymentName} [${nodeConfig.environment}]`,
+      fileExistsBehavior: 'OVERWRITE',
+      ignoreApplicationStopFailures: false,
+    }));
+
+    this.logger.log(`Deployment created: ${result.deploymentId}`);
+    return result.deploymentId;
+  }
+
+  /**
+   * 배포 전략 맵핑
+   */
+  private mapDeploymentStrategy(strategy?: string): string {
+    const strategyMap = {
+      'all-at-once': 'CodeDeployDefault.AllAtOnce',
+      'half-at-a-time': 'CodeDeployDefault.HalfAtATime',
+      'one-at-a-time': 'CodeDeployDefault.OneAtATime',
+      'blue-green': 'CodeDeployDefault.AllAtOnceBlueGreen',
+    };
+
+    return strategyMap[strategy] || 'CodeDeployDefault.AllAtOnce';
+  }
+
+  /**
+   * 배포 정보 DB 저장
+   */
+  private async saveDeploymentInfo(
+    deploymentId: string,
+    buildId: string,
+    projectId: string,
+    userId: string,
+    nodeConfig: DeploymentConfig,
+  ) {
+    const { error } = await this.supabaseService.client.from('deployments').insert({
+      deployment_id: deploymentId,
+      build_id: buildId,
+      project_id: projectId,
+      user_id: userId,
+      environment: nodeConfig.environment,
+      deployment_name: nodeConfig.deploymentName,
+      status: 'InProgress',
+      config: nodeConfig,
+      created_at: new Date().toISOString(),
+    });
+
+    if (error) {
+      this.logger.error('Failed to save deployment info', error);
+      // 저장 실패해도 배포는 계속 진행
+    }
+  }
+
+  /**
+   * 배포 상태 조회
+   */
+  async getDeploymentStatus(deploymentId: string): Promise<DeploymentStatus> {
+    const result = await this.client.send(new GetDeploymentCommand({
+      deploymentId,
+    }));
+
+    const status: DeploymentStatus = {
+      deploymentId,
+      status: result.deploymentInfo?.status as any || 'Unknown',
+      errorInformation: result.deploymentInfo?.errorInformation,
+      createTime: result.deploymentInfo?.createTime,
+      completeTime: result.deploymentInfo?.completeTime,
+      deploymentOverview: result.deploymentInfo?.deploymentOverview,
+      progress: this.calculateProgress(result.deploymentInfo?.status),
+    };
+
+    // DB 업데이트
+    await this.updateDeploymentStatus(deploymentId, status);
+
+    return status;
+  }
+
+  /**
+   * 진행률 계산
+   */
+  private calculateProgress(status?: string): number {
+    const progressMap = {
+      'Created': 10,
+      'Queued': 20,
+      'InProgress': 50,
+      'Baking': 70,
+      'Ready': 90,
+      'Succeeded': 100,
+      'Failed': 0,
+      'Stopped': 0,
+    };
+
+    return progressMap[status] || 0;
+  }
+
+  /**
+   * DB에 배포 상태 업데이트
+   */
+  private async updateDeploymentStatus(deploymentId: string, status: DeploymentStatus) {
+    const { error } = await this.supabaseService.client
+      .from('deployments')
+      .update({
+        status: status.status,
+        updated_at: new Date().toISOString(),
+        completed_at: status.completeTime ? new Date(status.completeTime).toISOString() : null,
+      })
+      .eq('deployment_id', deploymentId);
+
+    if (error) {
+      this.logger.error('Failed to update deployment status', error);
+    }
+  }
+
+  /**
+   * 배포 인스턴스 목록 조회
+   */
+  async listDeploymentInstances(deploymentId: string): Promise<string[]> {
+    const result = await this.client.send(new ListDeploymentInstancesCommand({
+      deploymentId,
+    }));
+
+    return result.instancesList || [];
+  }
+}

--- a/src/codedeploy/dto/create-deployment.dto.ts
+++ b/src/codedeploy/dto/create-deployment.dto.ts
@@ -1,0 +1,22 @@
+import { IsString, IsNotEmpty, IsObject, IsOptional } from 'class-validator';
+import { DeploymentConfig } from '../types/codedeploy.types';
+
+export class CreateDeploymentDto {
+  @IsString()
+  @IsNotEmpty()
+  buildId: string;
+
+  @IsString()
+  @IsNotEmpty()
+  projectId: string;
+
+  @IsObject()
+  @IsNotEmpty()
+  nodeConfig: DeploymentConfig;
+}
+
+export class GetDeploymentStatusDto {
+  @IsString()
+  @IsNotEmpty()
+  deploymentId: string;
+}

--- a/src/codedeploy/types/codedeploy.types.ts
+++ b/src/codedeploy/types/codedeploy.types.ts
@@ -1,0 +1,64 @@
+export interface DeploymentConfig {
+  deploymentName: string;
+  environment: 'development' | 'staging' | 'production';
+  targetType: 'ec2' | 'ecs' | 'lambda';
+  instanceTags?: Array<{
+    key: string;
+    value: string;
+  }>;
+  deploymentStrategy: {
+    type: 'all-at-once' | 'half-at-a-time' | 'one-at-a-time' | 'blue-green';
+    healthCheckUrl?: string;
+    waitTimeMinutes?: number;
+  };
+  rollbackConfig: {
+    enabled: boolean;
+    onDeploymentFailure: boolean;
+    onAlarmThreshold?: boolean;
+  };
+  notifications?: {
+    enabled: boolean;
+    events: ('start' | 'success' | 'failure')[];
+  };
+}
+
+export interface DeploymentResult {
+  deploymentId: string;
+  applicationName: string;
+  deploymentGroupName: string;
+  status: string;
+  createTime?: Date;
+}
+
+export interface DeploymentStatus {
+  deploymentId: string;
+  status: 'Created' | 'Queued' | 'InProgress' | 'Baking' | 'Succeeded' | 'Failed' | 'Stopped' | 'Ready';
+  errorInformation?: {
+    code?: string;
+    message?: string;
+  };
+  deploymentOverview?: {
+    Pending?: number;
+    InProgress?: number;
+    Succeeded?: number;
+    Failed?: number;
+    Stopped?: number;
+    Ready?: number;
+  };
+  createTime?: Date;
+  completeTime?: Date;
+  progress?: number;
+}
+
+export interface S3ArtifactLocation {
+  bucket: string;
+  key: string;
+  bundleType: 'zip' | 'tar' | 'tgz';
+}
+
+export interface DeploymentRequest {
+  buildId: string;
+  projectId: string;
+  userId: string;
+  nodeConfig: DeploymentConfig;
+}

--- a/src/pipeline/pipeline-executor.service.ts
+++ b/src/pipeline/pipeline-executor.service.ts
@@ -1,0 +1,372 @@
+import { Injectable, Logger, Inject, forwardRef } from '@nestjs/common';
+import { CodeBuildService } from '../codebuild/codebuild.service';
+import { CodeDeployService } from '../codedeploy/codedeploy.service';
+import { SupabaseService } from '../supabase/supabase.service';
+import { DeploymentConfig } from '../codedeploy/types/codedeploy.types';
+
+interface PipelineNode {
+  id: string;
+  type: string;
+  data: any;
+  position: { x: number; y: number };
+}
+
+interface PipelineEdge {
+  id: string;
+  source: string;
+  target: string;
+}
+
+interface ExecutionContext {
+  buildId?: string;
+  artifactLocation?: string;
+  deploymentId?: string;
+  [key: string]: any;
+}
+
+@Injectable()
+export class PipelineExecutorService {
+  private readonly logger = new Logger(PipelineExecutorService.name);
+
+  constructor(
+    @Inject(forwardRef(() => CodeBuildService))
+    private readonly codeBuildService: CodeBuildService,
+    private readonly codeDeployService: CodeDeployService,
+    private readonly supabaseService: SupabaseService,
+  ) {}
+
+  /**
+   * 파이프라인 실행
+   */
+  async executePipeline(
+    pipelineId: string,
+    userId: string,
+    projectId: string,
+  ): Promise<{ executionId: string; status: string }> {
+    this.logger.log('Starting pipeline execution', {
+      pipelineId,
+      userId,
+      projectId,
+    });
+
+    try {
+      // 1. 파이프라인 구성 로드
+      const pipeline = await this.loadPipeline(pipelineId);
+      if (!pipeline) {
+        throw new Error(`Pipeline not found: ${pipelineId}`);
+      }
+
+      // 2. 실행 순서 결정 (토폴로지 정렬)
+      const nodes = pipeline.data?.nodes || [];
+      const edges = pipeline.data?.edges || [];
+      const executionOrder = this.getExecutionOrder(nodes, edges);
+
+      // 3. 실행 ID 생성
+      const executionId = `exec-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+
+      // 4. 실행 정보 저장
+      await this.savePipelineExecution(executionId, pipelineId, userId, projectId);
+
+      // 5. 노드 순차 실행
+      let context: ExecutionContext = {};
+
+      for (const node of executionOrder) {
+        this.logger.log(`Executing node: ${node.type}`, { nodeId: node.id });
+
+        try {
+          context = await this.executeNode(node, context, userId, projectId);
+
+          // 노드 실행 상태 업데이트
+          await this.updateNodeStatus(executionId, node.id, 'success');
+        } catch (error) {
+          this.logger.error(`Node execution failed: ${node.type}`, error);
+
+          // 노드 실행 상태 업데이트
+          await this.updateNodeStatus(executionId, node.id, 'failed');
+
+          // 실패 시 파이프라인 중단
+          throw error;
+        }
+      }
+
+      // 6. 파이프라인 실행 완료
+      await this.completePipelineExecution(executionId, 'success');
+
+      return { executionId, status: 'success' };
+    } catch (error) {
+      this.logger.error('Pipeline execution failed', error);
+      throw error;
+    }
+  }
+
+  /**
+   * 파이프라인 로드
+   */
+  private async loadPipeline(pipelineId: string) {
+    const { data, error } = await this.supabaseService.client
+      .from('pipelines')
+      .select('*')
+      .eq('pipeline_id', pipelineId)
+      .single();
+
+    if (error) {
+      this.logger.error('Failed to load pipeline', error);
+      return null;
+    }
+
+    return data;
+  }
+
+  /**
+   * 노드 실행 순서 결정 (토폴로지 정렬)
+   */
+  private getExecutionOrder(nodes: PipelineNode[], edges: PipelineEdge[]): PipelineNode[] {
+    // 간단한 구현: 연결 순서대로 정렬
+    const nodeMap = new Map(nodes.map(node => [node.id, node]));
+    const visited = new Set<string>();
+    const result: PipelineNode[] = [];
+
+    // 시작 노드 찾기 (들어오는 엣지가 없는 노드)
+    const startNodes = nodes.filter(node =>
+      !edges.some(edge => edge.target === node.id)
+    );
+
+    // DFS로 순서 결정
+    const visit = (nodeId: string) => {
+      if (visited.has(nodeId)) return;
+      visited.add(nodeId);
+
+      const node = nodeMap.get(nodeId);
+      if (node) {
+        result.push(node);
+
+        // 다음 노드들 방문
+        edges
+          .filter(edge => edge.source === nodeId)
+          .forEach(edge => visit(edge.target));
+      }
+    };
+
+    // 시작 노드들부터 방문
+    startNodes.forEach(node => visit(node.id));
+
+    return result;
+  }
+
+  /**
+   * 개별 노드 실행
+   */
+  private async executeNode(
+    node: PipelineNode,
+    context: ExecutionContext,
+    userId: string,
+    projectId: string,
+  ): Promise<ExecutionContext> {
+    switch (node.type) {
+      // 빌드 노드들
+      case 'buildWebpack':
+      case 'buildVite':
+      case 'buildCustom':
+        return this.executeBuildNode(node, context, userId, projectId);
+
+      // 배포 노드
+      case 'deployNode':
+        return this.executeDeployNode(node, context, userId, projectId);
+
+      // 시작/종료 노드
+      case 'startNode':
+      case 'pipelineStart':
+      case 'endNode':
+        // 아무 작업도 하지 않고 컨텍스트 반환
+        return context;
+
+      // 테스트 노드들
+      case 'testJest':
+      case 'testMocha':
+      case 'testVitest':
+        // TODO: 테스트 실행 로직 구현
+        this.logger.warn(`Test node not yet implemented: ${node.type}`);
+        return context;
+
+      default:
+        this.logger.warn(`Unknown node type: ${node.type}`);
+        return context;
+    }
+  }
+
+  /**
+   * 빌드 노드 실행
+   */
+  private async executeBuildNode(
+    node: PipelineNode,
+    context: ExecutionContext,
+    userId: string,
+    projectId: string,
+  ): Promise<ExecutionContext> {
+    this.logger.log('Executing build node', { nodeType: node.type });
+
+    // CodeBuild 프로젝트명
+    const sanitizedProjectId = projectId.replace(/[^a-zA-Z0-9-]/g, '-');
+    const codebuildProjectName = `otto-${sanitizedProjectId}-${userId}`;
+
+    // buildspec 생성 (노드 타입에 따라)
+    const buildSpec = this.createBuildSpec(node);
+
+    // 빌드 시작
+    const buildResult = await this.codeBuildService.startBuild(
+      userId,
+      projectId,
+      codebuildProjectName,
+      buildSpec,
+      node.data.environmentVariables,
+    );
+
+    // 빌드 ID와 아티팩트 위치를 컨텍스트에 저장
+    return {
+      ...context,
+      buildId: buildResult.buildId,
+      artifactLocation: `otto-${sanitizedProjectId}-${userId}-artifacts/${buildResult.buildId}`,
+    };
+  }
+
+  /**
+   * 배포 노드 실행
+   */
+  private async executeDeployNode(
+    node: PipelineNode,
+    context: ExecutionContext,
+    userId: string,
+    projectId: string,
+  ): Promise<ExecutionContext> {
+    this.logger.log('Executing deploy node', { nodeType: node.type });
+
+    // 빌드 ID 확인
+    if (!context.buildId) {
+      throw new Error('No build ID found in context for deployment');
+    }
+
+    // 배포 설정 구성
+    const deploymentConfig: DeploymentConfig = {
+      deploymentName: node.data.deploymentName || 'Pipeline Deployment',
+      environment: node.data.environment || 'development',
+      targetType: node.data.targetType || 'ec2',
+      instanceTags: node.data.instanceTags || [
+        { key: 'Environment', value: node.data.environment || 'development' }
+      ],
+      deploymentStrategy: node.data.deploymentStrategy || {
+        type: 'all-at-once',
+      },
+      rollbackConfig: node.data.rollbackConfig || {
+        enabled: true,
+        onDeploymentFailure: true,
+      },
+    };
+
+    // 배포 실행
+    const deploymentResult = await this.codeDeployService.deployFromPipelineNode({
+      buildId: context.buildId,
+      projectId,
+      userId,
+      nodeConfig: deploymentConfig,
+    });
+
+    // 배포 ID를 컨텍스트에 저장
+    return {
+      ...context,
+      deploymentId: deploymentResult.deploymentId,
+    };
+  }
+
+  /**
+   * buildspec 생성
+   */
+  private createBuildSpec(node: PipelineNode): string {
+    const baseSpec = {
+      version: '0.2',
+      phases: {
+        install: {
+          'runtime-versions': {
+            nodejs: node.data.nodeVersion || '18',
+          },
+          commands: [
+            'echo "Installing dependencies..."',
+            node.data.packageManager === 'yarn' ? 'yarn install' : 'npm install',
+          ],
+        },
+        build: {
+          commands: [],
+        },
+      },
+      artifacts: {
+        files: ['**/*'],
+      },
+    };
+
+    // 노드 타입에 따라 빌드 명령어 설정
+    switch (node.type) {
+      case 'buildWebpack':
+        baseSpec.phases.build.commands = [
+          'echo "Building with Webpack..."',
+          'npx webpack --mode production',
+        ];
+        break;
+
+      case 'buildVite':
+        baseSpec.phases.build.commands = [
+          'echo "Building with Vite..."',
+          'npx vite build',
+        ];
+        break;
+
+      case 'buildCustom':
+        baseSpec.phases.build.commands = node.data.commands || [
+          'echo "Running custom build..."',
+          'npm run build',
+        ];
+        break;
+
+      default:
+        baseSpec.phases.build.commands = [
+          'echo "Running default build..."',
+          'npm run build',
+        ];
+    }
+
+    // YAML로 변환
+    const yaml = require('js-yaml');
+    return yaml.dump(baseSpec);
+  }
+
+  /**
+   * 파이프라인 실행 정보 저장
+   */
+  private async savePipelineExecution(
+    executionId: string,
+    pipelineId: string,
+    userId: string,
+    projectId: string,
+  ) {
+    // TODO: 실행 정보를 DB에 저장
+    this.logger.log('Saving pipeline execution', { executionId });
+  }
+
+  /**
+   * 노드 실행 상태 업데이트
+   */
+  private async updateNodeStatus(
+    executionId: string,
+    nodeId: string,
+    status: 'running' | 'success' | 'failed',
+  ) {
+    // TODO: 노드 상태를 DB에 업데이트
+    this.logger.log('Updating node status', { executionId, nodeId, status });
+  }
+
+  /**
+   * 파이프라인 실행 완료
+   */
+  private async completePipelineExecution(executionId: string, status: string) {
+    // TODO: 실행 완료 정보를 DB에 업데이트
+    this.logger.log('Completing pipeline execution', { executionId, status });
+  }
+}

--- a/src/pipeline/pipeline.controller.ts
+++ b/src/pipeline/pipeline.controller.ts
@@ -8,8 +8,11 @@ import {
   Param,
   Query,
   UseGuards,
+  Request,
+  Logger,
 } from '@nestjs/common';
 import { PipelineService } from './pipeline.service';
+import { PipelineExecutorService } from './pipeline-executor.service';
 import type {
   CreatePipelineDto,
   UpdatePipelineDto,
@@ -22,7 +25,12 @@ import { SupabaseAuthGuard } from '@/supabase/guards/supabase-auth.guard';
 @Controller('pipelines')
 @UseGuards(SupabaseAuthGuard)
 export class PipelineController {
-  constructor(private readonly pipelineService: PipelineService) {}
+  private readonly logger = new Logger(PipelineController.name);
+
+  constructor(
+    private readonly pipelineService: PipelineService,
+    private readonly pipelineExecutorService: PipelineExecutorService,
+  ) {}
 
   @Post()
   async createPipeline(
@@ -59,5 +67,29 @@ export class PipelineController {
   @Delete(':id')
   async deletePipeline(@Param('id') id: string): Promise<void> {
     return this.pipelineService.deletePipeline(id);
+  }
+
+  /**
+   * 파이프라인 실행
+   */
+  @Post(':id/execute')
+  async executePipeline(
+    @Request() req,
+    @Param('id') pipelineId: string,
+    @Body() dto: { projectId: string },
+  ) {
+    const userId = req.user.sub;
+
+    this.logger.log('Executing pipeline', {
+      pipelineId,
+      projectId: dto.projectId,
+      userId,
+    });
+
+    return this.pipelineExecutorService.executePipeline(
+      pipelineId,
+      userId,
+      dto.projectId,
+    );
   }
 }

--- a/src/pipeline/pipeline.module.ts
+++ b/src/pipeline/pipeline.module.ts
@@ -1,12 +1,19 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { PipelineController } from './pipeline.controller';
 import { PipelineService } from './pipeline.service';
+import { PipelineExecutorService } from './pipeline-executor.service';
 import { SupabaseModule } from '../supabase/supabase.module';
+import { CodeBuildModule } from '../codebuild/codebuild.module';
+import { CodeDeployModule } from '../codedeploy/codedeploy.module';
 
 @Module({
-  imports: [SupabaseModule],
+  imports: [
+    SupabaseModule,
+    forwardRef(() => CodeBuildModule),
+    CodeDeployModule,
+  ],
   controllers: [PipelineController],
-  providers: [PipelineService],
-  exports: [PipelineService],
+  providers: [PipelineService, PipelineExecutorService],
+  exports: [PipelineService, PipelineExecutorService],
 })
 export class PipelineModule {}

--- a/supabase/migrations/20240101000000_create_deployments_table.sql
+++ b/supabase/migrations/20240101000000_create_deployments_table.sql
@@ -1,0 +1,93 @@
+-- Create deployments table for tracking CodeDeploy deployments
+CREATE TABLE IF NOT EXISTS deployments (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  deployment_id VARCHAR(255) UNIQUE NOT NULL,
+  build_id UUID REFERENCES builds(build_id),
+  project_id VARCHAR(255) REFERENCES projects(project_id),
+  user_id UUID REFERENCES auth.users(id),
+
+  -- Deployment information
+  deployment_name VARCHAR(255),
+  environment VARCHAR(50) NOT NULL CHECK (environment IN ('development', 'staging', 'production')),
+  status VARCHAR(50) NOT NULL,
+
+  -- Configuration (stored as JSON)
+  config JSONB,
+
+  -- Results
+  deployment_url TEXT,
+  error_message TEXT,
+  instance_ids TEXT[],
+
+  -- Timestamps
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  completed_at TIMESTAMPTZ
+);
+
+-- Create indexes for better query performance
+CREATE INDEX idx_deployments_build_id ON deployments(build_id);
+CREATE INDEX idx_deployments_project_id ON deployments(project_id);
+CREATE INDEX idx_deployments_user_id ON deployments(user_id);
+CREATE INDEX idx_deployments_status ON deployments(status);
+CREATE INDEX idx_deployments_environment ON deployments(environment);
+CREATE INDEX idx_deployments_created_at ON deployments(created_at DESC);
+
+-- Create updated_at trigger
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER update_deployments_updated_at
+  BEFORE UPDATE ON deployments
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at_column();
+
+-- Create deployment history view for easier querying
+CREATE OR REPLACE VIEW deployment_history AS
+SELECT
+  d.id,
+  d.deployment_id,
+  d.deployment_name,
+  d.environment,
+  d.status,
+  d.created_at,
+  d.completed_at,
+  d.error_message,
+  b.build_id,
+  b.build_number,
+  b.build_status,
+  p.project_id,
+  p.project_name,
+  u.email as user_email
+FROM deployments d
+LEFT JOIN builds b ON d.build_id = b.build_id
+LEFT JOIN projects p ON d.project_id = p.project_id
+LEFT JOIN auth.users u ON d.user_id = u.id
+ORDER BY d.created_at DESC;
+
+-- Add RLS (Row Level Security) policies
+ALTER TABLE deployments ENABLE ROW LEVEL SECURITY;
+
+-- Policy: Users can view their own deployments
+CREATE POLICY "Users can view own deployments"
+  ON deployments FOR SELECT
+  USING (auth.uid() = user_id);
+
+-- Policy: Users can insert their own deployments
+CREATE POLICY "Users can insert own deployments"
+  ON deployments FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+-- Policy: Users can update their own deployments
+CREATE POLICY "Users can update own deployments"
+  ON deployments FOR UPDATE
+  USING (auth.uid() = user_id);
+
+-- Grant permissions
+GRANT ALL ON deployments TO authenticated;
+GRANT SELECT ON deployment_history TO authenticated;


### PR DESCRIPTION
### ✅ 구현된 기능

  1. 백엔드 (otto-server)
    - ✅ CodeDeploy 모듈 생성 (/src/codedeploy/)
    - ✅ CodeDeploy 서비스 구현 (AWS SDK 연동)
    - ✅ CodeDeploy 컨트롤러 (REST API + SSE
  스트리밍)
    - ✅ 파이프라인 실행 서비스 (CodeBuild →
  CodeDeploy 연계)
    - ✅ 데이터베이스 마이그레이션 (deployments
  테이블)
  2. 핵심 API 엔드포인트
    - POST /codedeploy/deploy-from-pipeline -
  파이프라인에서 배포 실행
    - GET /codedeploy/status/:deploymentId - 배포
  상태 조회
    - GET /codedeploy/stream/:deploymentId - 실시간
   상태 스트리밍 (SSE)
    - POST /pipelines/:id/execute - 파이프라인 실행
  3. 데이터 플로우
  파이프라인 실행 → 빌드 노드 → S3 저장 → 배포 노드
   → CodeDeploy → EC2

###   🔧 필요한 AWS 설정

  1. IAM 역할
    - CodeDeploy 서비스 역할 (AWSCodeDeployRole)
    - EC2 인스턴스 역할 (S3 읽기 권한)
  2. EC2 인스턴스
    - CodeDeploy Agent 설치
    - 태그 설정 (예: Environment=development)
  3. 환경 변수 추가
  AWS_CODEDEPLOY_SERVICE_ROLE=arn:aws:iam::12345678
  9:role/CodeDeployServiceRole
  CODEBUILD_ARTIFACTS_BUCKET=your-artifacts-bucket

###   📦 appspec.yml 템플릿

  빌드 아티팩트에 포함되어야 하는 파일:
  version: 0.0
  os: linux
  files:
    - source: /
      destination: /var/www/app
  hooks:
    BeforeInstall:
      - location: scripts/install_dependencies.sh
        timeout: 300
    ApplicationStart:
      - location: scripts/start_server.sh
        timeout: 300
    ValidateService:
      - location: scripts/validate_service.sh
        timeout: 300

###   🚀 사용 방법

  1. 파이프라인 구성 (프론트엔드에서)
    - 빌드 노드 추가
    - 배포 노드 추가 (환경, EC2 태그, 배포 전략
  설정)
    - 노드 연결
  2. 파이프라인 실행
  POST /pipelines/{pipelineId}/execute
  {
    "projectId": "your-project-id"
  }
  3. 배포 모니터링
    - SSE 스트림으로 실시간 상태 확인
    - 진행률 0-100% 표시
    - 성공/실패 상태 확인

  이제 프론트엔드에서 배포 노드 UI를 구현하면 전체
  CI/CD 파이프라인이 완성됩니다!